### PR TITLE
Event versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 go get github.com/stevecallear/salsa@latest
 ```
 
-See the [example](#) for a basic implementation using an in-memory event store.
+See the [example](https://github.com/stevecallear/salsa/tree/master/example) for a basic implementation using an in-memory event store.
 
 ## Aggregate
 
@@ -46,13 +46,11 @@ s := salsa.NewStore(db, salsa.WithResolver[state](salsa.EventResolverFunc[state]
 
 ### Snapshot Rate
 
-The store uses snapshots to reduce the amount of data that needs to be retrieved to build an aggregate. By default a snapshot is persisted every 10 events, but this value can be configured as part of the store options.
+The store uses snapshots to reduce the amount of data that needs to be retrieved to build an aggregate. By default a snapshot is persisted after at least 10 events have been applied. This value can be configured as part of the store options.
 
 ```
 s := salsa.NewStore(db, salsa.WithSnapshotRate[state](100))
 ```
-
-> Note: the store builds snapshots by replaying all events from the initial aggregate state. As a result, events must operate only on the supplied state.
 
 ### Encoding
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -3,9 +3,14 @@ package salsa
 type (
 	// Aggregate represents an aggregate root
 	Aggregate[T any] struct {
-		initState VersionedState[T]
-		currState T
-		events    []Event[T]
+		state    T
+		versions Versions
+		events   []Event[T]
+	}
+
+	// Versions represents aggergate versions
+	Versions struct {
+		State, Initial, Current uint64
 	}
 
 	// VersionedState represents versioned aggregate state
@@ -16,21 +21,38 @@ type (
 )
 
 // NewAggregate returns a new aggregate with the specified initial state
-func NewAggregate[T any](s VersionedState[T]) *Aggregate[T] {
-	return &Aggregate[T]{
-		initState: s,
-		currState: s.State,
+func NewAggregate[T any](s VersionedState[T], es ...Event[T]) (*Aggregate[T], error) {
+	a := &Aggregate[T]{
+		state: s.State,
+		versions: Versions{
+			State:   s.Version,
+			Initial: s.Version,
+			Current: s.Version,
+		},
 	}
-}
 
-// InitState returns the initial aggregate state
-func (a *Aggregate[T]) InitState() VersionedState[T] {
-	return a.initState
+	var err error
+	for _, e := range es {
+		a.state, err = e.Apply(a.state)
+		if err != nil {
+			return nil, err
+		}
+
+		a.versions.Initial++
+		a.versions.Current++
+	}
+
+	return a, nil
 }
 
 // State returns the current aggregate state
 func (a *Aggregate[T]) State() T {
-	return a.currState
+	return a.state
+}
+
+// Versions returns the aggregate versions
+func (a *Aggregate[T]) Versions() Versions {
+	return a.versions
 }
 
 // Events returns all events applied to the initial state
@@ -39,12 +61,14 @@ func (a *Aggregate[T]) Events() []Event[T] {
 }
 
 // Apply applies the specified event
-func (a *Aggregate[T]) Apply(e Event[T]) error {
-	ns, err := e.Apply(a.currState)
+func (a *Aggregate[T]) Apply(e Event[T]) (uint64, error) {
+	ns, err := e.Apply(a.state)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	a.currState = ns
+
+	a.state = ns
+	a.versions.Current++
 
 	if a.events == nil {
 		a.events = []Event[T]{e}
@@ -52,5 +76,5 @@ func (a *Aggregate[T]) Apply(e Event[T]) error {
 		a.events = append(a.events, e)
 	}
 
-	return nil
+	return a.versions.Current, nil
 }

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -128,7 +128,7 @@ func assertAggregateEqual(t *testing.T, act *salsa.Aggregate[state], exp aggrega
 }
 
 func newAggregate(s salsa.VersionedState[state], es ...salsa.Event[state]) *salsa.Aggregate[state] {
-	a, err := salsa.NewAggregate[state](s, es...)
+	a, err := salsa.NewAggregate(s, es...)
 	if err != nil {
 		panic(err)
 	}

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -6,6 +6,59 @@ import (
 	"github.com/stevecallear/salsa"
 )
 
+func TestNewAggregate(t *testing.T) {
+	evts := []salsa.Event[state]{
+		&event{Amount: 5},
+		&event{Amount: 10},
+	}
+
+	tests := []struct {
+		name   string
+		state  salsa.VersionedState[state]
+		events []salsa.Event[state]
+		exp    aggregate
+		err    bool
+	}{
+		{
+			name: "should return errors",
+			state: salsa.VersionedState[state]{
+				Version: 4,
+				State:   state{Balance: 10},
+			},
+			events: []salsa.Event[state]{new(errEvent)},
+			err:    true,
+		},
+		{
+			name: "should return the aggregate",
+			state: salsa.VersionedState[state]{
+				Version: 4,
+				State:   state{Balance: 10},
+			},
+			events: evts,
+			exp: aggregate{
+				state: state{Balance: 25},
+				versions: salsa.Versions{
+					State:   4,
+					Initial: 6,
+					Current: 6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			act, err := salsa.NewAggregate(tt.state, tt.events...)
+			assertErrorExists(t, err, tt.err)
+			if err != nil {
+				return
+			}
+
+			assertAggregateEqual(t, act, tt.exp)
+		})
+	}
+}
+
 func TestAggregate_Apply(t *testing.T) {
 	evts := []salsa.Event[state]{
 		&event{Amount: 5},
@@ -27,18 +80,19 @@ func TestAggregate_Apply(t *testing.T) {
 		},
 		{
 			name: "should apply the events",
-			sut: salsa.NewAggregate(salsa.VersionedState[state]{
+			sut: newAggregate(salsa.VersionedState[state]{
 				Version: 4,
 				State:   state{Balance: 10},
 			}),
 			events: evts,
 			exp: aggregate{
-				initState: salsa.VersionedState[state]{
-					Version: 4,
-					State:   state{Balance: 10},
+				state: state{Balance: 25},
+				versions: salsa.Versions{
+					State:   4,
+					Initial: 4,
+					Current: 6,
 				},
-				currState: state{Balance: 25},
-				events:    evts,
+				events: evts,
 			},
 		},
 	}
@@ -46,8 +100,12 @@ func TestAggregate_Apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, e := range tt.events {
-				err := tt.sut.Apply(e)
+				v, err := tt.sut.Apply(e)
 				assertErrorExists(t, err, tt.err)
+
+				if act, exp := v, tt.sut.Versions().Current; act != exp {
+					t.Errorf("got %d, expected %d", act, exp)
+				}
 			}
 
 			assertAggregateEqual(t, tt.sut, tt.exp)
@@ -56,15 +114,23 @@ func TestAggregate_Apply(t *testing.T) {
 }
 
 type aggregate struct {
-	initState salsa.VersionedState[state]
-	currState state
-	events    []salsa.Event[state]
+	state    state
+	versions salsa.Versions
+	events   []salsa.Event[state]
 }
 
 func assertAggregateEqual(t *testing.T, act *salsa.Aggregate[state], exp aggregate) {
 	assertDeepEqual(t, aggregate{
-		initState: act.InitState(),
-		currState: act.State(),
-		events:    act.Events(),
+		state:    act.State(),
+		versions: act.Versions(),
+		events:   act.Events(),
 	}, exp)
+}
+
+func newAggregate(s salsa.VersionedState[state], es ...salsa.Event[state]) *salsa.Aggregate[state] {
+	a, err := salsa.NewAggregate[state](s, es...)
+	if err != nil {
+		panic(err)
+	}
+	return a
 }

--- a/example/app.go
+++ b/example/app.go
@@ -30,7 +30,7 @@ func (s *AccountService) CreateAccount(ctx context.Context, id string, balance i
 		&CreateAccountEvent{ID: id},
 		&CreditAccountEvent{Amount: balance},
 	} {
-		if err := a.Apply(e); err != nil {
+		if _, err := a.Apply(e); err != nil {
 			return err
 		}
 	}
@@ -44,7 +44,7 @@ func (s *AccountService) CreditAccount(ctx context.Context, id string, amount in
 		return err
 	}
 
-	if err := a.Apply(&CreditAccountEvent{Amount: amount}); err != nil {
+	if _, err := a.Apply(&CreditAccountEvent{Amount: amount}); err != nil {
 		return err
 	}
 

--- a/store_memory.go
+++ b/store_memory.go
@@ -121,7 +121,7 @@ func (tx *memTX) State(s EncodedState) error {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 
-	if s.Version != tx.version+1 {
+	if s.Version != tx.version {
 		return errors.New("version conflict")
 	}
 


### PR DESCRIPTION
This PR updates the contract to make aggregates control the event versioning strategy, with every event resulting in a version iteration. Previously this was controlled by the store and snapshots resulted in an explicit version, but this resulted in unpredictable behaviour and limited the use of aggregate versions outside of the persistence context.